### PR TITLE
Use correct return type and add test for getAxios

### DIFF
--- a/src/XAPI.ts
+++ b/src/XAPI.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosRequestConfig, AxiosPromise, AxiosInstance } from "axios";
+import axios, { AxiosRequestConfig, AxiosPromise, AxiosStatic } from "axios";
 import { AttachmentUsages, Resources, Verbs, Versions } from "./constants";
 import { parseMultiPart } from "./internal/multiPart";
 import { formatEndpoint } from "./internal/formatEndpoint";
@@ -104,7 +104,7 @@ export default class XAPI {
     };
   }
 
-  public getAxios(): AxiosInstance {
+  public getAxios(): AxiosStatic {
     return axios;
   }
 

--- a/src/XAPI.unit.test.ts
+++ b/src/XAPI.unit.test.ts
@@ -58,4 +58,13 @@ describe("xapi constructor", () => {
       })
     );
   });
+
+  test("can return the internal axios instance", () => {
+    const xapi = new XAPI({
+      endpoint: testEndpoint,
+      version: "1.0.0",
+    });
+    const axiosStatic = xapi.getAxios();
+    expect(axiosStatic).toEqual(axios);
+  });
 });


### PR DESCRIPTION
Before merging in https://github.com/xapijs/xapi/pull/289, I would like to propose a couple of changes. I didn't have edit rights on your fork so I've had to make a PR to your PR 😅

Changes made:
- Changed `getAxios` return type from `AxiosInstance` to `AxiosStatic`
- Added unit test for `getAxios` method